### PR TITLE
fix broken deletelist url on index

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -16,7 +16,7 @@
 	<a href="${ url_for('edit') }">Neues Schild</a>
 	
 	<py:if test="defined('files')">
-        <form method="POST" action="/deletelist">
+	<form method="POST" action="${ url_for('deletelist') }">
 	<ul>
 		<li py:for="file in files">
                 <input id="form:${file}" type="checkbox" name="filenames" value="${file}"/>


### PR DESCRIPTION
The URL for the `deletelist` function on the index page is currently hard-coded. This is broken when the software is hosted under a document root other than `/`.

This commit replaces the hard-coded bit with the usual url_for function call.
