### PR TITLE
Use /usr/bin/env python2 to support virtualenvs

### DIFF
--- a/schilder.py
+++ b/schilder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # -*- encoding: utf8 -*-
 
 from flask import Flask, flash, session, redirect, url_for, escape, request, Response, Markup


### PR DESCRIPTION
Would be useful.
Virtualenvs are generally better to deploy than installing packages globally, particularly with pip.
And this still works on distributions where python == python3.
Of course this breaks execution on Mac OS, where there is no python2.